### PR TITLE
Feature/bad word deactivate(wr9 34)

### DIFF
--- a/src/main/java/io/crops/warmletter/domain/badword/controller/BadWordController.java
+++ b/src/main/java/io/crops/warmletter/domain/badword/controller/BadWordController.java
@@ -2,15 +2,13 @@ package io.crops.warmletter.domain.badword.controller;
 
 
 import io.crops.warmletter.domain.badword.dto.request.CreateBadWordRequest;
+import io.crops.warmletter.domain.badword.dto.request.UpdateBadWordStatusRequest;
 import io.crops.warmletter.domain.badword.service.BadWordService;
 import io.crops.warmletter.global.response.BaseResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/bad-words")
@@ -25,5 +23,15 @@ public class BadWordController {
         badWordService.createBadWord(request);
         return ResponseEntity.ok(BaseResponse.of(null, "검열단어 등록완료"));
     }
+
+    @PatchMapping("/{badWordId}/status")
+    public ResponseEntity<BaseResponse<Void>> updateBadWordStatus(
+            @PathVariable Long badWordId,
+            @RequestBody @Valid UpdateBadWordStatusRequest request) {
+
+        badWordService.updateBadWordStatus(badWordId, request);
+        return ResponseEntity.ok(BaseResponse.of(null, "금칙어 상태 변경 완료"));
+    }
+
 
 }

--- a/src/main/java/io/crops/warmletter/domain/badword/controller/BadWordController.java
+++ b/src/main/java/io/crops/warmletter/domain/badword/controller/BadWordController.java
@@ -21,7 +21,7 @@ public class BadWordController {
     @PostMapping
     public ResponseEntity<BaseResponse<Void>> createBadWord(@RequestBody @Valid CreateBadWordRequest request) {
         badWordService.createBadWord(request);
-        return ResponseEntity.ok(BaseResponse.of(null, "검열단어 등록완료"));
+        return ResponseEntity.ok(BaseResponse.of(null, "금칙어 등록완료"));
     }
 
     @PatchMapping("/{badWordId}/status")

--- a/src/main/java/io/crops/warmletter/domain/badword/dto/request/UpdateBadWordStatusRequest.java
+++ b/src/main/java/io/crops/warmletter/domain/badword/dto/request/UpdateBadWordStatusRequest.java
@@ -9,6 +9,5 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class UpdateBadWordStatusRequest {
-    @NotNull(message = "상태값은 필수입니다.")
-    private Boolean isUsed;
+    private boolean isUsed;
 }

--- a/src/main/java/io/crops/warmletter/domain/badword/dto/request/UpdateBadWordStatusRequest.java
+++ b/src/main/java/io/crops/warmletter/domain/badword/dto/request/UpdateBadWordStatusRequest.java
@@ -1,0 +1,14 @@
+package io.crops.warmletter.domain.badword.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateBadWordStatusRequest {
+    @NotNull(message = "상태값은 필수입니다.")
+    private Boolean isUsed;
+}

--- a/src/main/java/io/crops/warmletter/domain/badword/entity/BadWord.java
+++ b/src/main/java/io/crops/warmletter/domain/badword/entity/BadWord.java
@@ -24,10 +24,10 @@ public class BadWord extends BaseEntity {
     private String word;
 
     @Column(nullable = false)
-    private Boolean isUsed;
+    private boolean isUsed;
 
 
-    public void updateStatus(Boolean isUsed) {
+    public void updateStatus(boolean isUsed) {
         this.isUsed = isUsed;
     }
 

--- a/src/main/java/io/crops/warmletter/domain/badword/entity/BadWord.java
+++ b/src/main/java/io/crops/warmletter/domain/badword/entity/BadWord.java
@@ -26,4 +26,10 @@ public class BadWord extends BaseEntity {
     @Column(nullable = false)
     private Boolean isUsed;
 
+
+    public void updateStatus(Boolean isUsed) {
+        this.isUsed = isUsed;
+    }
+
+
 }

--- a/src/main/java/io/crops/warmletter/domain/badword/exception/BadWordNotFoundException.java
+++ b/src/main/java/io/crops/warmletter/domain/badword/exception/BadWordNotFoundException.java
@@ -1,0 +1,10 @@
+package io.crops.warmletter.domain.badword.exception;
+
+import io.crops.warmletter.global.error.common.ErrorCode;
+import io.crops.warmletter.global.error.exception.BusinessException;
+
+public class BadWordNotFoundException extends BusinessException {
+    public BadWordNotFoundException() {
+        super(ErrorCode.BAD_WORD_NOT_FOUND); // 에러코드 추가 필요
+    }
+}

--- a/src/main/java/io/crops/warmletter/domain/badword/service/BadWordService.java
+++ b/src/main/java/io/crops/warmletter/domain/badword/service/BadWordService.java
@@ -2,9 +2,12 @@ package io.crops.warmletter.domain.badword.service;
 
 
 import io.crops.warmletter.domain.badword.dto.request.CreateBadWordRequest;
+import io.crops.warmletter.domain.badword.dto.request.UpdateBadWordStatusRequest;
 import io.crops.warmletter.domain.badword.entity.BadWord;
+import io.crops.warmletter.domain.badword.exception.BadWordNotFoundException;
 import io.crops.warmletter.domain.badword.exception.DuplicateBadWordException;
 import io.crops.warmletter.domain.badword.repository.BadWordRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
@@ -29,9 +32,26 @@ public class BadWordService {
                 .isUsed(true)
                 .build();
 
+
         badWordRepository.save(badWord);
 
         redisTemplate.opsForSet().add("bad_word", word);
     }
+
+
+    @Transactional
+    public void updateBadWordStatus(Long badWordId, UpdateBadWordStatusRequest request) {
+        BadWord badWord = badWordRepository.findById(badWordId)
+                .orElseThrow(BadWordNotFoundException::new);
+
+        badWord.updateStatus(request.getIsUsed());
+
+        if (request.getIsUsed()) {
+            redisTemplate.opsForSet().add("bad_word", badWord.getWord());
+        } else {
+            redisTemplate.opsForSet().remove("bad_word", badWord.getWord());
+        }
+    }
+
 
 }

--- a/src/main/java/io/crops/warmletter/domain/badword/service/BadWordService.java
+++ b/src/main/java/io/crops/warmletter/domain/badword/service/BadWordService.java
@@ -44,9 +44,10 @@ public class BadWordService {
         BadWord badWord = badWordRepository.findById(badWordId)
                 .orElseThrow(BadWordNotFoundException::new);
 
-        badWord.updateStatus(request.getIsUsed());
 
-        if (request.getIsUsed()) {
+        badWord.updateStatus(request.isUsed());
+
+        if (request.isUsed()) {
             redisTemplate.opsForSet().add("bad_word", badWord.getWord());
         } else {
             redisTemplate.opsForSet().remove("bad_word", badWord.getWord());

--- a/src/main/java/io/crops/warmletter/global/error/common/ErrorCode.java
+++ b/src/main/java/io/crops/warmletter/global/error/common/ErrorCode.java
@@ -13,6 +13,8 @@ public enum ErrorCode {
 
     //금치어
     DUPLICATE_BANNED_WORD("MOD-001", HttpStatus.CONFLICT, "이미 등록된 금칙어입니다."),
+    BAD_WORD_NOT_FOUND("MOD-002", HttpStatus.NOT_FOUND, "해당 금칙어가 존재하지 않습니다."),
+
 
     // OAuth2 관련 에러 코드
     UNSUPPORTED_SOCIAL_LOGIN("AUTH-001", HttpStatus.BAD_REQUEST, "지원하지 않는 소셜 로그인입니다."),

--- a/src/test/java/io/crops/warmletter/domain/badword/controller/BadWordControllerTest.java
+++ b/src/test/java/io/crops/warmletter/domain/badword/controller/BadWordControllerTest.java
@@ -2,9 +2,9 @@ package io.crops.warmletter.domain.badword.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.crops.warmletter.domain.badword.dto.request.CreateBadWordRequest;
+import io.crops.warmletter.domain.badword.dto.request.UpdateBadWordStatusRequest;
 import io.crops.warmletter.domain.badword.entity.BadWord;
 import io.crops.warmletter.domain.badword.repository.BadWordRepository;
-import io.crops.warmletter.domain.badword.service.BadWordService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -12,14 +12,17 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
+@ActiveProfiles("test")
 @AutoConfigureMockMvc(addFilters = false)
 class BadWordControllerTest {
 
@@ -41,7 +44,7 @@ class BadWordControllerTest {
     @Test
     @DisplayName("검열 단어 등록 성공")
     void createBadWord_Success() throws Exception {
-        CreateBadWordRequest request = new CreateBadWordRequest("badword");
+        CreateBadWordRequest request = new CreateBadWordRequest("씹새끼ㅌ");
 
 
         mockMvc.perform(post("/api/bad-words")
@@ -82,6 +85,56 @@ class BadWordControllerTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isConflict())  // 409 상태 코드로 수정
                 .andExpect(jsonPath("$.message").value("이미 등록된 금칙어입니다."));  // 메시지 검증
+    }
+
+    @Test
+    @DisplayName("금치어 상태 변경 성공")
+    void updateBadWordStatus_Success() throws Exception {
+        //Given
+        BadWord badWord = badWordRepository.save(
+                BadWord.builder()
+                        .word("badword")
+                        .isUsed(false)
+                        .build()
+        );
+        UpdateBadWordStatusRequest request = new UpdateBadWordStatusRequest(true);
+        mockMvc.perform(patch("/api/bad-words/{badWordId}/status", badWord.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("금칙어 상태 변경 완료"));
+    }
+
+
+    @Test
+    @DisplayName("금칙어 상태 변경 실패 - 존재하지 않는 ID")
+    void updateBadWordStatus_NotFound_Fail() throws Exception {
+        UpdateBadWordStatusRequest request = new UpdateBadWordStatusRequest(true);
+
+        mockMvc.perform(patch("/api/bad-words/{badWordId}/status", 999L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("해당 금칙어가 존재하지 않습니다."));
+    }
+
+    @Test
+    @DisplayName("금칙어 상태 변경 실패 - 잘못된 요청값")
+    void updateBadWordStatus_InvalidRequest_Fail() throws Exception {
+        BadWord badWord = badWordRepository.save(
+                BadWord.builder()
+                        .word("badword")
+                        .isUsed(false)
+                        .build()
+        );
+
+        UpdateBadWordStatusRequest request = new UpdateBadWordStatusRequest(null);
+
+        mockMvc.perform(patch("/api/bad-words/{badWordId}/status", badWord.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("상태값은 필수입니다."));
     }
 
 }

--- a/src/test/java/io/crops/warmletter/domain/badword/controller/BadWordControllerTest.java
+++ b/src/test/java/io/crops/warmletter/domain/badword/controller/BadWordControllerTest.java
@@ -23,7 +23,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@ActiveProfiles("test")
+
 @Import(TestConfig.class)
 @SpringBootTest
 @ActiveProfiles("test")

--- a/src/test/java/io/crops/warmletter/domain/badword/controller/BadWordControllerTest.java
+++ b/src/test/java/io/crops/warmletter/domain/badword/controller/BadWordControllerTest.java
@@ -44,14 +44,14 @@ class BadWordControllerTest {
     @Test
     @DisplayName("검열 단어 등록 성공")
     void createBadWord_Success() throws Exception {
-        CreateBadWordRequest request = new CreateBadWordRequest("씹새끼ㅌ");
+        CreateBadWordRequest request = new CreateBadWordRequest("씹새끼");
 
 
         mockMvc.perform(post("/api/bad-words")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("검열단어 등록완료"));
+                .andExpect(jsonPath("$.message").value("금칙어 등록완료"));
     }
 
 
@@ -117,24 +117,4 @@ class BadWordControllerTest {
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.message").value("해당 금칙어가 존재하지 않습니다."));
     }
-
-    @Test
-    @DisplayName("금칙어 상태 변경 실패 - 잘못된 요청값")
-    void updateBadWordStatus_InvalidRequest_Fail() throws Exception {
-        BadWord badWord = badWordRepository.save(
-                BadWord.builder()
-                        .word("badword")
-                        .isUsed(false)
-                        .build()
-        );
-
-        UpdateBadWordStatusRequest request = new UpdateBadWordStatusRequest(null);
-
-        mockMvc.perform(patch("/api/bad-words/{badWordId}/status", badWord.getId())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("상태값은 필수입니다."));
-    }
-
 }

--- a/src/test/java/io/crops/warmletter/domain/badword/service/BadWordServiceTest.java
+++ b/src/test/java/io/crops/warmletter/domain/badword/service/BadWordServiceTest.java
@@ -1,6 +1,9 @@
 package io.crops.warmletter.domain.badword.service;
 
 import io.crops.warmletter.domain.badword.dto.request.CreateBadWordRequest;
+import io.crops.warmletter.domain.badword.dto.request.UpdateBadWordStatusRequest;
+import io.crops.warmletter.domain.badword.entity.BadWord;
+import io.crops.warmletter.domain.badword.exception.BadWordNotFoundException;
 import io.crops.warmletter.domain.badword.exception.DuplicateBadWordException;
 import io.crops.warmletter.domain.badword.repository.BadWordRepository;
 import io.crops.warmletter.global.error.common.ErrorCode;
@@ -11,12 +14,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.test.annotation.DirtiesContext;
-
+import org.springframework.test.context.ActiveProfiles;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 
 @SpringBootTest
+@ActiveProfiles("test")
 @Transactional // 테스트 끝나면 롤백 (DB 안 지저분해짐)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD) // 각 테스트 끝날 때마다 컨텍스트 초기화 (DB 상태 초기화 효과)
 class BadWordServiceTest {
@@ -59,5 +64,65 @@ class BadWordServiceTest {
                 .isInstanceOf(DuplicateBadWordException.class)
                 .hasMessageContaining(ErrorCode.DUPLICATE_BANNED_WORD.getMessage());
     }
+
+    @Test
+    @DisplayName("금칙어 상태 업데이트 - 활성화 성공")
+    void updateBadWordStatus_activate_success() {
+        // given
+        BadWord badWord = BadWord.builder()
+                .word("비속어")
+                .isUsed(false)
+                .build();
+        badWordRepository.save(badWord);
+
+        UpdateBadWordStatusRequest request = new UpdateBadWordStatusRequest(true);
+
+        // when
+        badWordService.updateBadWordStatus(badWord.getId(), request);
+
+        // then
+        BadWord updatedBadWord = badWordRepository.findById(badWord.getId()).orElseThrow();
+        assertTrue(updatedBadWord.getIsUsed());
+        assertTrue(redisTemplate.opsForSet().isMember("bad_word", "비속어"));
+    }
+
+
+    @Test
+    @DisplayName("금칙어 상태 업데이트 - 비활성화 성공")
+    void updateBadWordStatus_deactivate_success() {
+        // given
+        BadWord badWord = BadWord.builder()
+                .word("비속어")
+                .isUsed(true)
+                .build();
+        badWordRepository.save(badWord);
+        redisTemplate.opsForSet().add("bad_word", "비속어");
+
+        UpdateBadWordStatusRequest request = new UpdateBadWordStatusRequest(false);
+
+        // when
+        badWordService.updateBadWordStatus(badWord.getId(), request);
+
+        // then
+        BadWord updatedBadWord = badWordRepository.findById(badWord.getId()).orElseThrow();
+        assertFalse(updatedBadWord.getIsUsed());
+        assertFalse(redisTemplate.opsForSet().isMember("bad_word", "비속어"));
+    }
+
+    @Test
+    @DisplayName("금칙어 상태 업데이트 - 금칙어가 없을 때 실패")
+    void updateBadWordStatus_notFound_fail() {
+        // given
+        Long invalidId = 999L;
+        UpdateBadWordStatusRequest request = new UpdateBadWordStatusRequest(true);
+
+        // when & then
+        assertThatThrownBy(() -> badWordService.updateBadWordStatus(invalidId, request))
+                .isInstanceOf(BadWordNotFoundException.class);
+    }
+
+
+
+
 
 }

--- a/src/test/java/io/crops/warmletter/domain/badword/service/BadWordServiceTest.java
+++ b/src/test/java/io/crops/warmletter/domain/badword/service/BadWordServiceTest.java
@@ -82,7 +82,7 @@ class BadWordServiceTest {
 
         // then
         BadWord updatedBadWord = badWordRepository.findById(badWord.getId()).orElseThrow();
-        assertTrue(updatedBadWord.getIsUsed());
+        assertTrue(updatedBadWord.isUsed());
         assertTrue(redisTemplate.opsForSet().isMember("bad_word", "비속어"));
     }
 
@@ -105,7 +105,7 @@ class BadWordServiceTest {
 
         // then
         BadWord updatedBadWord = badWordRepository.findById(badWord.getId()).orElseThrow();
-        assertFalse(updatedBadWord.getIsUsed());
+        assertFalse(updatedBadWord.isUsed());
         assertFalse(redisTemplate.opsForSet().isMember("bad_word", "비속어"));
     }
 

--- a/src/test/java/io/crops/warmletter/domain/badword/service/BadWordServiceTest.java
+++ b/src/test/java/io/crops/warmletter/domain/badword/service/BadWordServiceTest.java
@@ -26,7 +26,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @ActiveProfiles("test")
 @Import(TestConfig.class)
 @SpringBootTest
-@ActiveProfiles("test")
 @Transactional // 테스트 끝나면 롤백 (DB 안 지저분해짐)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD) // 각 테스트 끝날 때마다 컨텍스트 초기화 (DB 상태 초기화 효과)
 class BadWordServiceTest {

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -8,7 +8,7 @@ spring:
       enabled: true
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: create
       naming:
         physical-strategy: org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy
     show-sql: true


### PR DESCRIPTION
# Pull Request Template

## 📝 PR 설명

금칙어 상태 변경(활성화/비활성화) 기능 추가

## 🔍 주요 변경사항

- [x] PATCH /api/bad-words/{badWordId}/status 엔드포인트 추가
- [x] BadWordService에 금칙어 상태 변경(isUsed true/false) 로직 추가
- [x] 금칙어 활성화 시 Redis에 추가, 비활성화 시 Redis에서 삭제 기능 추가
- [ ]  BadWordControllerTest - 상태 변경 성공/실패 통합 테스트 추가

## 📸 스크린샷 (선택사항)

- UI 변경사항이 있다면 스크린샷을 첨부해주세요.

## 🧪 테스트

- [x] 단위 테스트 추가/수정
- [x] 테스트 커버리지 확인
- [x] 소나클라우드 품질 게이트 통과

## ✅ 체크리스트

- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 코드나 주석이 없나요?
- [ ] 브랜치 네이밍 컨벤션을 따랐나요?
- [ ] 관련 문서를 업데이트했나요?

## 🤝 관련 이슈

- closes #이슈번호
