### PR TITLE
Feature/delete event post(wr9 40)

### DIFF
--- a/src/main/java/io/crops/warmletter/domain/eventpost/controller/EventPostController.java
+++ b/src/main/java/io/crops/warmletter/domain/eventpost/controller/EventPostController.java
@@ -8,10 +8,9 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
 
 @Slf4j
 @RestController
@@ -20,9 +19,15 @@ import org.springframework.web.bind.annotation.RestController;
 public class EventPostController {
     private final EventPostService eventPostService;
 
+    // 이벤트 게시판 생성
     @PostMapping("/admin/event-posts")
     public ResponseEntity<BaseResponse<CreateEventPostResponse>> createEventPost(@RequestBody @Valid CreateEventPostRequest createEventPostRequest){
-        CreateEventPostResponse createEventPostResponse = eventPostService.createEventPost(createEventPostRequest);
-        return ResponseEntity.ok(BaseResponse.of(createEventPostResponse,"게시판 생성 완료"));
+        return ResponseEntity.ok(BaseResponse.of(eventPostService.createEventPost(createEventPostRequest),"게시판 생성 완료"));
+    }
+
+    // 이벤트 게시판 삭제(임시,미정)
+    @DeleteMapping("/admin/event-posts/{eventPostId}")
+    public ResponseEntity<BaseResponse<Map<String,Long>>> deleteEventPost(@PathVariable Long eventPostId){
+        return ResponseEntity.ok(BaseResponse.of(eventPostService.deleteEventPost(eventPostId),"게시판 삭제 완료"));
     }
 }

--- a/src/main/java/io/crops/warmletter/domain/eventpost/dto/request/CreateEventPostRequest.java
+++ b/src/main/java/io/crops/warmletter/domain/eventpost/dto/request/CreateEventPostRequest.java
@@ -12,11 +12,8 @@ public class CreateEventPostRequest {
     @NotBlank(message = "제목을 입력해주세요.")
     private String title;
 
-    private String content;
-
     @Builder
     public CreateEventPostRequest(String title, String content) {
         this.title = title;
-        this.content = content;
     }
 }

--- a/src/main/java/io/crops/warmletter/domain/eventpost/dto/request/CreateEventPostRequest.java
+++ b/src/main/java/io/crops/warmletter/domain/eventpost/dto/request/CreateEventPostRequest.java
@@ -13,7 +13,7 @@ public class CreateEventPostRequest {
     private String title;
 
     @Builder
-    public CreateEventPostRequest(String title, String content) {
+    public CreateEventPostRequest(String title) {
         this.title = title;
     }
 }

--- a/src/main/java/io/crops/warmletter/domain/eventpost/dto/response/CreateEventPostResponse.java
+++ b/src/main/java/io/crops/warmletter/domain/eventpost/dto/response/CreateEventPostResponse.java
@@ -14,7 +14,7 @@ public class CreateEventPostResponse {
     private String title;
 
     @Builder
-    public CreateEventPostResponse(Long eventPostId, String title, String content) {
+    public CreateEventPostResponse(Long eventPostId, String title) {
         this.eventPostId = eventPostId;
         this.title = title;
     }

--- a/src/main/java/io/crops/warmletter/domain/eventpost/dto/response/CreateEventPostResponse.java
+++ b/src/main/java/io/crops/warmletter/domain/eventpost/dto/response/CreateEventPostResponse.java
@@ -12,12 +12,10 @@ import java.time.LocalDateTime;
 public class CreateEventPostResponse {
     private long eventPostId;
     private String title;
-    private String content;
 
     @Builder
     public CreateEventPostResponse(Long eventPostId, String title, String content) {
         this.eventPostId = eventPostId;
         this.title = title;
-        this.content = content;
     }
 }

--- a/src/main/java/io/crops/warmletter/domain/eventpost/entity/EventPost.java
+++ b/src/main/java/io/crops/warmletter/domain/eventpost/entity/EventPost.java
@@ -21,9 +21,15 @@ public class EventPost extends BaseEntity {
 
     private String content;
 
+    private Boolean isUsed;
+
     @Builder
     public EventPost(String title, String content) {
         this.title = title;
         this.content = content;
+    }
+
+    public void softDelete(){
+        this.isUsed = false;
     }
 }

--- a/src/main/java/io/crops/warmletter/domain/eventpost/entity/EventPost.java
+++ b/src/main/java/io/crops/warmletter/domain/eventpost/entity/EventPost.java
@@ -8,7 +8,6 @@ import lombok.*;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 @Table(name = "event_posts")
 public class EventPost extends BaseEntity {
     @Id

--- a/src/main/java/io/crops/warmletter/domain/eventpost/entity/EventPost.java
+++ b/src/main/java/io/crops/warmletter/domain/eventpost/entity/EventPost.java
@@ -19,14 +19,11 @@ public class EventPost extends BaseEntity {
 
     private String title;
 
-    private String content;
-
     private Boolean isUsed;
 
     @Builder
-    public EventPost(String title, String content) {
+    public EventPost(String title) {
         this.title = title;
-        this.content = content;
     }
 
     public void softDelete(){

--- a/src/main/java/io/crops/warmletter/domain/eventpost/entity/EventPost.java
+++ b/src/main/java/io/crops/warmletter/domain/eventpost/entity/EventPost.java
@@ -3,14 +3,12 @@ package io.crops.warmletter.domain.eventpost.entity;
 import io.crops.warmletter.global.entity.BaseEntity;
 import io.crops.warmletter.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 @Table(name = "event_posts")
 public class EventPost extends BaseEntity {
     @Id
@@ -24,6 +22,7 @@ public class EventPost extends BaseEntity {
     @Builder
     public EventPost(String title) {
         this.title = title;
+        this.isUsed = false;    // 기본 값 비활성화
     }
 
     public void softDelete(){

--- a/src/main/java/io/crops/warmletter/domain/eventpost/exception/EventPostNotFoundException.java
+++ b/src/main/java/io/crops/warmletter/domain/eventpost/exception/EventPostNotFoundException.java
@@ -1,0 +1,10 @@
+package io.crops.warmletter.domain.eventpost.exception;
+
+import io.crops.warmletter.global.error.common.ErrorCode;
+import io.crops.warmletter.global.error.exception.BusinessException;
+
+public class EventPostNotFoundException extends BusinessException {
+    public EventPostNotFoundException() {
+        super(ErrorCode.EVENT_POST_NOT_FOUND);
+    }
+}

--- a/src/main/java/io/crops/warmletter/domain/eventpost/service/EventPostService.java
+++ b/src/main/java/io/crops/warmletter/domain/eventpost/service/EventPostService.java
@@ -15,21 +15,18 @@ import java.util.Map;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class EventPostService {
     private final EventPostRepository eventPostRepository;
 
     public CreateEventPostResponse createEventPost(CreateEventPostRequest createEventPostRequest) {
         EventPost eventPost = EventPost.builder()
                 .title(createEventPostRequest.getTitle())
-                .content(createEventPostRequest.getContent())
                 .build();
         EventPost saveEventPost = eventPostRepository.save(eventPost);
 
         return CreateEventPostResponse.builder()
                 .eventPostId(saveEventPost.getId())
                 .title(saveEventPost.getTitle())
-                .content(saveEventPost.getContent())
                 .build();
     }
 

--- a/src/main/java/io/crops/warmletter/domain/eventpost/service/EventPostService.java
+++ b/src/main/java/io/crops/warmletter/domain/eventpost/service/EventPostService.java
@@ -3,11 +3,14 @@ package io.crops.warmletter.domain.eventpost.service;
 import io.crops.warmletter.domain.eventpost.dto.request.CreateEventPostRequest;
 import io.crops.warmletter.domain.eventpost.dto.response.CreateEventPostResponse;
 import io.crops.warmletter.domain.eventpost.entity.EventPost;
+import io.crops.warmletter.domain.eventpost.exception.EventPostNotFoundException;
 import io.crops.warmletter.domain.eventpost.repository.EventPostRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
 
 @Slf4j
 @Service
@@ -28,5 +31,12 @@ public class EventPostService {
                 .title(saveEventPost.getTitle())
                 .content(saveEventPost.getContent())
                 .build();
+    }
+
+    @Transactional
+    public Map<String, Long> deleteEventPost(long eventPostId) {
+        EventPost eventPost = eventPostRepository.findById(eventPostId).orElseThrow(EventPostNotFoundException::new);
+        eventPost.softDelete();
+        return Map.of("eventPostId", eventPost.getId());
     }
 }

--- a/src/main/java/io/crops/warmletter/domain/eventpost/service/EventPostService.java
+++ b/src/main/java/io/crops/warmletter/domain/eventpost/service/EventPostService.java
@@ -33,7 +33,6 @@ public class EventPostService {
     @Transactional
     public Map<String, Long> deleteEventPost(long eventPostId) {
         EventPost eventPost = eventPostRepository.findById(eventPostId).orElseThrow(EventPostNotFoundException::new);
-        eventPost.softDelete();
         return Map.of("eventPostId", eventPost.getId());
     }
 }

--- a/src/main/java/io/crops/warmletter/domain/eventpost/service/EventPostService.java
+++ b/src/main/java/io/crops/warmletter/domain/eventpost/service/EventPostService.java
@@ -15,6 +15,7 @@ import java.util.Map;
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class EventPostService {
     private final EventPostRepository eventPostRepository;
 
@@ -30,9 +31,9 @@ public class EventPostService {
                 .build();
     }
 
-    @Transactional
     public Map<String, Long> deleteEventPost(long eventPostId) {
         EventPost eventPost = eventPostRepository.findById(eventPostId).orElseThrow(EventPostNotFoundException::new);
+        eventPost.softDelete();
         return Map.of("eventPostId", eventPost.getId());
     }
 }

--- a/src/main/java/io/crops/warmletter/global/error/common/ErrorCode.java
+++ b/src/main/java/io/crops/warmletter/global/error/common/ErrorCode.java
@@ -15,6 +15,9 @@ public enum ErrorCode {
     INVALID_PAGE_REQUEST("SHARE-001", HttpStatus.BAD_REQUEST, "요청페이지 번호가 0보다 작습니다."),
     SHARE_POST_NOT_FOUND("SHARE-002",HttpStatus.NOT_FOUND,"해당 공유 게시글을 찾을 수 없습니다."),
 
+    // 이벤트 게시판 관련 에러 코드
+    EVENT_POST_NOT_FOUND("EVENT-001",HttpStatus.NOT_FOUND,"해당 이벤트 게시글을 찾을 수 없습니다."),
+
     //금치어
     DUPLICATE_BANNED_WORD("MOD-001", HttpStatus.CONFLICT, "이미 등록된 금칙어입니다."),
     BAD_WORD_NOT_FOUND("MOD-002", HttpStatus.NOT_FOUND, "해당 금칙어가 존재하지 않습니다."),

--- a/src/test/java/io/crops/warmletter/domain/eventpost/controller/EventPostControllerTest.java
+++ b/src/test/java/io/crops/warmletter/domain/eventpost/controller/EventPostControllerTest.java
@@ -42,13 +42,11 @@ class EventPostControllerTest {
         //given
         CreateEventPostRequest createEventPostRequest = CreateEventPostRequest.builder()
                 .title("제목")
-                .content("")
                 .build();
 
         CreateEventPostResponse createEventPostResponse = CreateEventPostResponse.builder()
                 .eventPostId(1L)
                 .title("제목")
-                .content("")
                 .build();
 
         when(eventPostService.createEventPost(any(CreateEventPostRequest.class))).thenReturn(createEventPostResponse);
@@ -60,7 +58,6 @@ class EventPostControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.eventPostId").value(createEventPostResponse.getEventPostId()))
                 .andExpect(jsonPath("$.data.title").value("제목"))
-                .andExpect(jsonPath("$.data.content").value(""))
                 .andExpect(jsonPath("$.message").value("게시판 생성 완료"))
                 .andDo(print());
     }
@@ -71,7 +68,6 @@ class EventPostControllerTest {
         //given
         CreateEventPostRequest createEventPostRequest = CreateEventPostRequest.builder()
                 .title("")
-                .content("내용")
                 .build();
 
         //when & then

--- a/src/test/java/io/crops/warmletter/domain/eventpost/controller/EventPostControllerTest.java
+++ b/src/test/java/io/crops/warmletter/domain/eventpost/controller/EventPostControllerTest.java
@@ -4,19 +4,31 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.crops.warmletter.config.TestConfig;
 import io.crops.warmletter.domain.eventpost.dto.request.CreateEventPostRequest;
 import io.crops.warmletter.domain.eventpost.dto.response.CreateEventPostResponse;
+import io.crops.warmletter.domain.eventpost.entity.EventPost;
+import io.crops.warmletter.domain.eventpost.exception.EventPostNotFoundException;
 import io.crops.warmletter.domain.eventpost.service.EventPostService;
+import io.crops.warmletter.global.response.BaseResponse;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -38,8 +50,8 @@ class EventPostControllerTest {
 
     @Test
     @DisplayName("게시판 생성 성공")
-    void create_event_post_success () throws Exception {
-        //given
+    void create_event_post_success() throws Exception {
+        // given
         CreateEventPostRequest createEventPostRequest = CreateEventPostRequest.builder()
                 .title("제목")
                 .build();
@@ -49,21 +61,22 @@ class EventPostControllerTest {
                 .title("제목")
                 .build();
 
-        when(eventPostService.createEventPost(any(CreateEventPostRequest.class))).thenReturn(createEventPostResponse);
+        when(eventPostService.createEventPost(any(CreateEventPostRequest.class)))
+                .thenReturn(createEventPostResponse);
 
-        //when & then
+        // when & then
         mockMvc.perform(post("/api/admin/event-posts")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(createEventPostRequest)))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.eventPostId").value(createEventPostResponse.getEventPostId()))
-                .andExpect(jsonPath("$.data.title").value("제목"))
-                .andExpect(jsonPath("$.message").value("게시판 생성 완료"))
-                .andDo(print());
+                .andExpect(status().isOk()) // 상태 코드 검증
+                .andExpect(jsonPath("$.data.eventPostId").value(1L)) // 반환된 eventPostId 검증
+                .andExpect(jsonPath("$.data.title").value("제목")) // 반환된 title 검증
+                .andExpect(jsonPath("$.message").value("게시판 생성 완료")) // 반환된 message 검증
+                .andDo(print()); // 응답 출력
     }
 
     @Test
-    @DisplayName("게시판 생성 실패(NotExistTitle)")
+    @DisplayName("게시판 생성 실패 - title 값이 없음")
     void create_event_post_not_exist_title () throws Exception {
         //given
         CreateEventPostRequest createEventPostRequest = CreateEventPostRequest.builder()
@@ -77,5 +90,36 @@ class EventPostControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value("제목을 입력해주세요."))
                 .andDo(print());
+    }
+
+    @Test
+    @DisplayName("게시판 삭제 성공")
+    void delete_event_post_success() throws Exception {
+        // given
+        long eventPostId = 1L;
+
+        when(eventPostService.deleteEventPost(eventPostId)).thenReturn(Map.of("eventPostId", eventPostId));
+
+        // when & then
+        mockMvc.perform(delete("/api/admin/event-posts/{eventPostId}", eventPostId))
+                .andExpect(status().isOk()) // 상태 코드 200 OK 검증
+                .andExpect(jsonPath("$.message").value("게시판 삭제 완료")) // 성공 메시지 검증
+                .andExpect(jsonPath("$.data.eventPostId").value(eventPostId)) // 삭제된 eventPostId 검증
+                .andDo(print()); // 응답 출력
+    }
+
+    @Test
+    @DisplayName("게시판 삭제 실패 - 일치하는 eventPostId 없음")
+    void delete_event_post_not_found() throws Exception {
+        // given
+        long eventPostId = 999L; // 존재하지 않는 게시판 ID
+
+        when(eventPostService.deleteEventPost(eventPostId)).thenThrow(new EventPostNotFoundException());
+
+        // when & then
+        mockMvc.perform(delete("/api/admin/event-posts/{eventPostId}", eventPostId))
+                .andExpect(status().isNotFound()) // 상태 코드 404 Not Found 검증
+                .andExpect(jsonPath("$.message").value("해당 이벤트 게시글을 찾을 수 없습니다.")) // 실패 메시지 검증
+                .andDo(print()); // 응답 출력
     }
 }

--- a/src/test/java/io/crops/warmletter/domain/eventpost/service/EventPostServiceTest.java
+++ b/src/test/java/io/crops/warmletter/domain/eventpost/service/EventPostServiceTest.java
@@ -33,12 +33,10 @@ class EventPostServiceTest {
         //given
         CreateEventPostRequest createEventPostRequest = CreateEventPostRequest.builder()
                 .title("제목")
-                .content("내용")
                 .build();
 
         EventPost eventPost = EventPost.builder()
                 .title(createEventPostRequest.getTitle())
-                .content(createEventPostRequest.getContent())
                 .build();
 
         when(eventPostRepository.save(any(EventPost.class))).thenReturn(eventPost);
@@ -50,6 +48,5 @@ class EventPostServiceTest {
         then(eventPostRepository).should(times(1)).save(any(EventPost.class));
 
         assertEquals("제목", createEventPostResponse.getTitle());
-        assertEquals("내용", createEventPostResponse.getContent());
     }
 }

--- a/src/test/java/io/crops/warmletter/domain/eventpost/service/EventPostServiceTest.java
+++ b/src/test/java/io/crops/warmletter/domain/eventpost/service/EventPostServiceTest.java
@@ -11,6 +11,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Map;
 import java.util.Optional;
@@ -59,7 +60,8 @@ class EventPostServiceTest {
         //given
         long eventPostId = 1L;
 
-        EventPost eventPost = new EventPost(1L,"제목",false);
+        EventPost eventPost = EventPost.builder().title("제목").build();
+        ReflectionTestUtils.setField(eventPost, "id", eventPostId);
 
         when(eventPostRepository.findById(any(Long.class))).thenReturn(Optional.of(eventPost));
 

--- a/src/test/java/io/crops/warmletter/domain/eventpost/service/EventPostServiceTest.java
+++ b/src/test/java/io/crops/warmletter/domain/eventpost/service/EventPostServiceTest.java
@@ -12,6 +12,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.context.ActiveProfiles;
 
+import java.util.Map;
+import java.util.Optional;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.then;
@@ -48,5 +51,25 @@ class EventPostServiceTest {
         then(eventPostRepository).should(times(1)).save(any(EventPost.class));
 
         assertEquals("제목", createEventPostResponse.getTitle());
+    }
+
+    @Test
+    @DisplayName("게시판 삭제 성공")
+    void deleteEventPost_success(){
+        //given
+        long eventPostId = 1L;
+
+        EventPost eventPost = new EventPost(1L,"제목",false);
+
+        when(eventPostRepository.findById(any(Long.class))).thenReturn(Optional.of(eventPost));
+
+        //when
+        Map<String,Long> deleteEventPostResponse = eventPostService.deleteEventPost(eventPostId);
+
+
+        //then
+        then(eventPostRepository).should(times(1)).findById(any(Long.class));
+
+        assertEquals(1, deleteEventPostResponse.get("eventPostId"));
     }
 }


### PR DESCRIPTION
# Pull Request Template

## 📝 PR 설명

- 이벤트 게시판 삭제 API 개발

## 🔍 주요 변경사항

- [x] DELETE /api/admin/event-posts 엔드포인트 추가
- [x] EventPostService - 이벤트 게시판 삭제 로직 추가
- [x] Entity - isUsed 추가 및 관련 사항 변경

## 📸 스크린샷 (선택사항)

- UI 변경사항이 있다면 스크린샷을 첨부해주세요.

## 🧪 테스트

- [x] 단위 테스트 추가/수정
- [x] 테스트 커버리지 확인
- [x] 소나클라우드 품질 게이트 통과

## ✅ 체크리스트

- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 코드나 주석이 없나요?
- [x] 브랜치 네이밍 컨벤션을 따랐나요?
- [x] 관련 문서를 업데이트했나요?

## 🤝 관련 이슈

- (관리자)삭제 기능은 추후 도입 미정으로 소프트딜리트 컬럼인 isActive을 기존 isUsed(사용여부)를 대체하여 같은 기능으로 사용
- closes #41 
