### PR TITLE
Refactor/letter retrieval(wr9-101)

### DIFF
--- a/src/main/java/io/crops/warmletter/domain/letter/controller/LetterController.java
+++ b/src/main/java/io/crops/warmletter/domain/letter/controller/LetterController.java
@@ -40,7 +40,7 @@ public class LetterController implements LetterControllerDocs {
     /**
      * 지정된 letterId의 이전 편지를 조회합니다.
      */
-    @GetMapping("/v1/letters/{letterId}/previous")
+    @GetMapping("/letters/{letterId}/previous")
     public ResponseEntity<BaseResponse<List<LetterResponse>>> getPreviousLetters(@PathVariable Long letterId) {
         List<LetterResponse> previousLetters = letterService.getPreviousLetters(letterId);
         BaseResponse<List<LetterResponse>> response = BaseResponse.of(previousLetters, "이전 편지가 전송 완료.");

--- a/src/main/java/io/crops/warmletter/domain/letter/entity/Letter.java
+++ b/src/main/java/io/crops/warmletter/domain/letter/entity/Letter.java
@@ -39,10 +39,8 @@ public class Letter extends BaseTimeEntity {
     @Column(nullable = false)
     private Status status;  // 배송 상태 (IN_DELIVERY, DELIVERED 등)
 
-    @Column(nullable = false)
     private LocalDateTime deliveryStartedAt;    // 배송 시작 시간
 
-    @Column(nullable = false)
     private LocalDateTime deliveryCompletedAt;  // 배송 도착 시간
 
     private boolean isRead;          // 열람 여부 (YES/NO 대신 boolean 처리)
@@ -76,7 +74,7 @@ public class Letter extends BaseTimeEntity {
         this.content = content;
         this.status = status;
         this.deliveryStartedAt = LocalDateTime.now();
-        this.deliveryCompletedAt = LocalDateTime.now().plusHours(1); //편지 생성 시, 답장 시 한 시간 뒤에 도착
+        this.deliveryCompletedAt = LocalDateTime.now().plusMinutes(1); //편지 생성 시, 답장 시 한 시간 뒤에 도착
         this.isRead = false;
         this.fontType = fontType;
         this.paperType = paperType;

--- a/src/main/java/io/crops/warmletter/domain/letter/entity/Letter.java
+++ b/src/main/java/io/crops/warmletter/domain/letter/entity/Letter.java
@@ -116,4 +116,8 @@ public class Letter extends BaseTimeEntity {
     public void updateIsEvaluated(boolean isEvaluated) {
         this.isEvaluated = isEvaluated;
     }
+
+    public void updateStatus(Status status) {
+        this.status = status;
+    }
 }

--- a/src/main/java/io/crops/warmletter/domain/letter/repository/LetterMatchingRepository.java
+++ b/src/main/java/io/crops/warmletter/domain/letter/repository/LetterMatchingRepository.java
@@ -41,7 +41,7 @@ public interface LetterMatchingRepository extends JpaRepository<LetterMatching, 
             "COALESCE(COUNT(l), 0)" +
             ") " +
             "FROM LetterMatching lm " +
-            "LEFT JOIN Letter l ON lm.id = l.matchingId " +
+            "LEFT JOIN Letter l ON lm.id = l.matchingId AND l.status = 'DELIVERED' " +
             "JOIN Member m ON (CASE WHEN lm.firstMemberId = :myId THEN lm.secondMemberId ELSE lm.firstMemberId END) = m.id " +
             "WHERE lm.firstMemberId = :myId OR lm.secondMemberId = :myId " +
             "GROUP BY lm.id, m.zipCode, lm.isActive " +

--- a/src/main/java/io/crops/warmletter/domain/letter/repository/LetterRepository.java
+++ b/src/main/java/io/crops/warmletter/domain/letter/repository/LetterRepository.java
@@ -11,6 +11,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -62,4 +64,6 @@ public interface LetterRepository extends JpaRepository<Letter, Long> {
             "AND l.isActive = true " +
             "AND l.status = 'SAVED'")
     Optional<Letter> findByIdAndWriterIdAndStatusIsSAVED(Long id, Long writerId);
+
+    List<Letter> findByStatusAndDeliveryCompletedAtLessThanEqual(Status status, LocalDateTime now);
 }

--- a/src/main/java/io/crops/warmletter/domain/letter/repository/LetterTemporaryMatchingRepository.java
+++ b/src/main/java/io/crops/warmletter/domain/letter/repository/LetterTemporaryMatchingRepository.java
@@ -1,14 +1,9 @@
 package io.crops.warmletter.domain.letter.repository;
 
 import io.crops.warmletter.domain.letter.entity.LetterTemporaryMatching;
-import io.lettuce.core.dynamic.annotation.Param;
-import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 
 @Repository

--- a/src/main/java/io/crops/warmletter/domain/letter/service/LetterService.java
+++ b/src/main/java/io/crops/warmletter/domain/letter/service/LetterService.java
@@ -128,9 +128,11 @@ public class LetterService {
             List<LetterResponse> responses = new ArrayList<>();
 
             for (Letter findLetter : lettersByParentId) {
-                String zipCode = memberRepository.findById(findLetter.getWriterId()).orElseThrow(MemberNotFoundException::new).getZipCode();
-                LetterResponse response = LetterResponse.fromEntityForPreviousLetters(findLetter,zipCode);
-                responses.add(response);
+                if(findLetter.getStatus().equals(Status.DELIVERED)){
+                    String zipCode = memberRepository.findById(findLetter.getWriterId()).orElseThrow(MemberNotFoundException::new).getZipCode();
+                    LetterResponse response = LetterResponse.fromEntityForPreviousLetters(findLetter,zipCode);
+                    responses.add(response);
+                }
             }
             return responses;
         }

--- a/src/main/java/io/crops/warmletter/domain/letter/service/LetterService.java
+++ b/src/main/java/io/crops/warmletter/domain/letter/service/LetterService.java
@@ -112,21 +112,28 @@ public class LetterService {
         Letter letter = letterRepository.findById(letterId).orElseThrow(LetterNotFoundException::new);
         Long parentLetterId = letter.getParentLetterId(); //답장하는 편지의 부모 id
 
-        Long matchingId = letter.getMatchingId();
-        LetterMatching letterMatching = letterMatchingRepository.findById(matchingId).orElseThrow(MatchingNotFoundException::new);
-        if (!letterMatching.getFirstMemberId().equals(myId) && !letterMatching.getSecondMemberId().equals(myId)) {
-            throw new MatchingNotBelongException();
-        }
+        if(parentLetterId == null){
+            String zipCode = memberRepository.findById(letter.getWriterId()).orElseThrow(MemberNotFoundException::new).getZipCode();
+            LetterResponse response = LetterResponse.fromEntityForPreviousLetters(letter,zipCode);
+            return List.of(response);
 
-        List<Letter> lettersByParentId = letterRepository.findLettersByParentLetterId(parentLetterId); //부모아이디로 편지 찾기
+        }else{
+            Long matchingId = letter.getMatchingId();
+            LetterMatching letterMatching = letterMatchingRepository.findById(matchingId).orElseThrow(MatchingNotFoundException::new);
+            if (!letterMatching.getFirstMemberId().equals(myId) && !letterMatching.getSecondMemberId().equals(myId)) {
+                throw new MatchingNotBelongException();
+            }
 
-        List<LetterResponse> responses = new ArrayList<>();
-        for (Letter findLetter : lettersByParentId) {
-            String zipCode = memberRepository.findById(findLetter.getWriterId()).orElseThrow(MemberNotFoundException::new).getZipCode();
-            LetterResponse response = LetterResponse.fromEntityForPreviousLetters(findLetter,zipCode);
-            responses.add(response);
+            List<Letter> lettersByParentId = letterRepository.findLettersByParentLetterId(parentLetterId); //부모아이디로 편지 찾기
+            List<LetterResponse> responses = new ArrayList<>();
+
+            for (Letter findLetter : lettersByParentId) {
+                String zipCode = memberRepository.findById(findLetter.getWriterId()).orElseThrow(MemberNotFoundException::new).getZipCode();
+                LetterResponse response = LetterResponse.fromEntityForPreviousLetters(findLetter,zipCode);
+                responses.add(response);
+            }
+            return responses;
         }
-        return responses;
     }
 
     @Transactional //더티채킹

--- a/src/main/java/io/crops/warmletter/global/schedule/AutoCancelSchedule.java
+++ b/src/main/java/io/crops/warmletter/global/schedule/AutoCancelSchedule.java
@@ -24,7 +24,7 @@ public class AutoCancelSchedule {
     private final LetterRepository letterRepository;
 
     @Transactional
-    @Scheduled(cron = "0 */1 * * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 */3 * * * *", zone = "Asia/Seoul")
     public void checkAndDeleteExpiredMatchings() {
         String currentTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
         log.info("--------- 자동 매칭 취소 처리 시작: {} ---------", currentTime);

--- a/src/main/java/io/crops/warmletter/global/schedule/AutoCancelSchedule.java
+++ b/src/main/java/io/crops/warmletter/global/schedule/AutoCancelSchedule.java
@@ -1,0 +1,60 @@
+package io.crops.warmletter.global.schedule;
+
+import io.crops.warmletter.domain.letter.entity.LetterTemporaryMatching;
+import io.crops.warmletter.domain.letter.enums.LetterType;
+import io.crops.warmletter.domain.letter.repository.LetterRepository;
+import io.crops.warmletter.domain.letter.repository.LetterTemporaryMatchingRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class AutoCancelSchedule {
+
+    private final LetterTemporaryMatchingRepository letterTemporaryMatchingRepository;
+    private final LetterRepository letterRepository;
+
+    @Transactional
+    @Scheduled(cron = "0 */1 * * * *", zone = "Asia/Seoul")
+    public void checkAndDeleteExpiredMatchings() {
+        String currentTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+        log.info("--------- 자동 매칭 취소 처리 시작: {} ---------", currentTime);
+
+        List<LetterTemporaryMatching> expiredMatchings = letterTemporaryMatchingRepository.findAll().stream()
+                .filter(m -> m.getReplyDeadLine().isBefore(LocalDateTime.now()) ||
+                        m.getReplyDeadLine().isEqual(LocalDateTime.now()))
+                .collect(Collectors.toList());
+
+        log.info("찾은 만료 매칭 수: {}", expiredMatchings.size());
+
+        for (LetterTemporaryMatching matching : expiredMatchings) {
+            log.info("매칭 ID: {}, 기한: {}, 현재: {}",
+                    matching.getId(), matching.getReplyDeadLine(), LocalDateTime.now());
+
+            // 편지 처리 - LetterType을 RANDOM으로 변경
+            letterRepository.findById(matching.getLetterId())
+                    .ifPresent(letter -> {
+                        letter.updateLetterType(LetterType.RANDOM);
+                        letterRepository.save(letter);
+                    });
+        }
+
+        // 매칭 삭제 처리
+        if (!expiredMatchings.isEmpty()) {
+            letterTemporaryMatchingRepository.deleteAll(expiredMatchings);
+            log.info("매칭 {}개 삭제 완료", expiredMatchings.size());
+        } else {
+            log.info("삭제할 만료 매칭이 없습니다.");
+        }
+        log.info("--------- 자동 매칭 취소 처리 완료 ---------");
+    }
+}

--- a/src/main/java/io/crops/warmletter/global/schedule/DeliverySchedule.java
+++ b/src/main/java/io/crops/warmletter/global/schedule/DeliverySchedule.java
@@ -1,0 +1,52 @@
+package io.crops.warmletter.global.schedule;
+
+import io.crops.warmletter.domain.letter.entity.Letter;
+import io.crops.warmletter.domain.letter.enums.Status;
+import io.crops.warmletter.domain.letter.repository.LetterRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.Scheduled;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class DeliverySchedule {
+
+    private final LetterRepository letterRepository;
+
+    @Transactional
+    @Scheduled(cron = "0 */1 * * * *", zone = "Asia/Seoul")
+    public void processDeliveryCompletion() {
+        String currentTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+        log.info("--------- 배송 완료 처리 시작: {} ---------", currentTime);
+
+        LocalDateTime now = LocalDateTime.now();
+
+        // 배송 완료 조건을 만족하는 편지 목록 조회 (배송 중이면서 배송 완료 시간이 현재보다 이전인 편지)
+        List<Letter> lettersToComplete = letterRepository.findByStatusAndDeliveryCompletedAtLessThanEqual(
+                Status.IN_DELIVERY, now);
+
+        if (!lettersToComplete.isEmpty()) {
+            log.info("배송 완료 처리할 편지 수: {}", lettersToComplete.size());
+
+            // 각 편지의 상태를 DELIVERED로 변경
+            for (Letter letter : lettersToComplete) {
+                letter.updateStatus(Status.DELIVERED);
+                log.info("편지 ID: {} 배송 완료 처리됨", letter.getId());
+            }
+
+            // 변경사항 저장
+            letterRepository.saveAll(lettersToComplete);
+            log.info("총 {}개의 편지 배송 완료 처리됨", lettersToComplete.size());
+        } else {
+            log.info("배송 완료 처리할 편지가 없습니다.");
+        }
+        log.info("--------- 배송 완료 처리 완료 ---------");
+    }
+}

--- a/src/test/java/io/crops/warmletter/domain/letter/controller/LettersControllerUnitTest.java
+++ b/src/test/java/io/crops/warmletter/domain/letter/controller/LettersControllerUnitTest.java
@@ -79,7 +79,7 @@ class LettersControllerUnitTest {
         when(letterService.getPreviousLetters(1L)).thenReturn(letterResponses);
 
         // when & then
-        mockMvc.perform(get("/api/v1/letters/{letterId}/previous", 1L)
+        mockMvc.perform(get("/api/letters/{letterId}/previous", 1L)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data").isArray())

--- a/src/test/java/io/crops/warmletter/domain/letter/service/LetterServiceTest.java
+++ b/src/test/java/io/crops/warmletter/domain/letter/service/LetterServiceTest.java
@@ -489,6 +489,87 @@ class LetterServiceTest {
     }
 
     @Test
+    @DisplayName("이전 편지 목록 조회 - 일부 편지 상태가 DELIVERED가 아닌 경우 테스트")
+    void getPreviousLetters_withNonDeliveredLetters() {
+        // 현재 사용자 ID 설정
+        Long myId = 1L;
+        when(authFacade.getCurrentUserId()).thenReturn(myId);
+
+        Long replyLetterId = 5L;
+        Long parentLetterId = 10L;
+        Long matchingId = 100L;
+        Letter replyLetter = Letter.builder()
+                .writerId(myId) // 답장 쓴 사람이 현재 사용자라고 가정
+                .parentLetterId(parentLetterId)
+                .matchingId(matchingId)
+                .title("답장 제목")
+                .content("답장 내용")
+                .fontType(FontType.HIMCHAN)
+                .paperType(PaperType.COMFORT)
+                .status(Status.DELIVERED)
+                .build();
+        ReflectionTestUtils.setField(replyLetter, "id", replyLetterId);
+
+        // 매칭 정보
+        LetterMatching matching = LetterMatching.builder()
+                .firstMemberId(myId)
+                .secondMemberId(2L)
+                .build();
+        ReflectionTestUtils.setField(matching, "id", matchingId);
+
+        // 이전 편지 목록: 다양한 상태의 편지들 포함
+        Letter deliveredLetter = Letter.builder()
+                .writerId(2L)
+                .receiverId(myId)
+                .parentLetterId(parentLetterId)
+                .letterType(LetterType.DIRECT)
+                .title("배달된 편지 제목")
+                .content("배달된 편지 내용")
+                .fontType(FontType.HIMCHAN)
+                .paperType(PaperType.COMFORT)
+                .status(Status.DELIVERED)
+                .build();
+        ReflectionTestUtils.setField(deliveredLetter, "id", 11L);
+
+        Letter pendingLetter = Letter.builder()
+                .writerId(2L)
+                .receiverId(myId)
+                .parentLetterId(parentLetterId)
+                .letterType(LetterType.DIRECT)
+                .title("저장 중인 편지 제목")
+                .content("저장 중인 편지 내용")
+                .fontType(FontType.KYOBO)
+                .paperType(PaperType.BASIC)
+                .status(Status.SAVED)
+                .build();
+        ReflectionTestUtils.setField(pendingLetter, "id", 12L);
+
+        List previousLetters = List.of(deliveredLetter, pendingLetter);
+
+        when(letterRepository.findById(replyLetterId)).thenReturn(Optional.of(replyLetter));
+        when(letterRepository.findLettersByParentLetterId(parentLetterId)).thenReturn(previousLetters);
+        when(letterMatchingRepository.findById(matchingId)).thenReturn(Optional.of(matching));
+        when(memberRepository.findById(2L)).thenReturn(Optional.of(Member.builder().zipCode("12345").build()));
+
+        // when
+        List<LetterResponse> responses = letterService.getPreviousLetters(replyLetterId);
+
+        // then
+        assertAll("이전 편지 목록 검증",
+                () -> assertNotNull(responses),
+                () -> assertEquals(1, responses.size(), "DELIVERED 상태인 편지만 반환되어야 함"),
+                () -> assertEquals("배달된 편지 제목", responses.get(0).getTitle()),
+                () -> assertEquals("배달된 편지 내용", responses.get(0).getContent()),
+                () -> assertEquals("12345", responses.get(0).getZipCode())
+        );
+
+        verify(letterRepository).findById(replyLetterId);
+        verify(letterRepository).findLettersByParentLetterId(parentLetterId);
+        verify(letterMatchingRepository).findById(matchingId);
+        verify(memberRepository).findById(2L);
+    }
+
+    @Test
     @DisplayName("getPreviousLetters - 매칭 정보가 없으면 MatchingNotFoundException 발생")
     void getPreviousLetters_matchingNotFound() {
         // given

--- a/src/test/java/io/crops/warmletter/domain/letter/service/LetterServiceTest.java
+++ b/src/test/java/io/crops/warmletter/domain/letter/service/LetterServiceTest.java
@@ -568,6 +568,50 @@ class LetterServiceTest {
         verify(letterMatchingRepository).findById(matchingId);
         verify(memberRepository).findById(2L);
     }
+    @Test
+    @DisplayName("이전 편지 목록 조회 - 부모 편지 ID가 null인 경우 테스트")
+    void getPreviousLetters_withNullParentLetterId() {
+        // 현재 사용자 ID 설정
+        Long myId = 1L;
+        when(authFacade.getCurrentUserId()).thenReturn(myId);
+
+        Long letterId = 5L;
+        Long writerId = 2L;
+        Letter letter = Letter.builder()
+                .writerId(writerId)
+                .title("부모 편지 ID가 null인 편지 제목")
+                .content("부모 편지 ID가 null인 편지 내용")
+                .fontType(FontType.HIMCHAN)
+                .paperType(PaperType.COMFORT)
+                .status(Status.DELIVERED)
+                .parentLetterId(null) // 부모 편지 ID를 null로 설정
+                .build();
+        ReflectionTestUtils.setField(letter, "id", letterId);
+
+        // 편지 작성자 회원 정보
+        Member writer = Member.builder()
+                .zipCode("54321")
+                .build();
+
+        when(letterRepository.findById(letterId)).thenReturn(Optional.of(letter));
+        when(memberRepository.findById(writerId)).thenReturn(Optional.of(writer));
+
+        // when
+        List<LetterResponse> responses = letterService.getPreviousLetters(letterId);
+
+        // then
+        assertAll("부모 편지 ID가 null인 경우 편지 목록 검증",
+                () -> assertNotNull(responses, "반환된 목록은 null이 아니어야 함"),
+                () -> assertEquals(1, responses.size(), "단일 편지가 반환되어야 함"),
+                () -> assertEquals("부모 편지 ID가 null인 편지 제목", responses.get(0).getTitle()),
+                () -> assertEquals("부모 편지 ID가 null인 편지 내용", responses.get(0).getContent()),
+                () -> assertEquals("54321", responses.get(0).getZipCode())
+        );
+
+        verify(letterRepository).findById(letterId);
+        verify(memberRepository).findById(writerId);
+    }
+
 
     @Test
     @DisplayName("getPreviousLetters - 매칭 정보가 없으면 MatchingNotFoundException 발생")


### PR DESCRIPTION
# Pull Request Template

## 📝 PR 설명

- 편지함 상세조회시 배송된 것만 조회되게 수정
- 이전편지 조회 시 첫편지는 첫편지로 응답으로 변경
- 24시간 뒤 매칭 취소, 배송완료 스케줄러로 도입

## 🔍 주요 변경사항

- [x] 편지 전송시간 임시로 1분 설정

## 📸 스크린샷 (선택사항)

- UI 변경사항이 있다면 스크린샷을 첨부해주세요.

## 🧪 테스트

- [x] 단위 테스트 추가/수정
- [x] 테스트 커버리지 확인
- [x] 소나클라우드 품질 게이트 통과

## ✅ 체크리스트

- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 코드나 주석이 없나요?
- [x] 브랜치 네이밍 컨벤션을 따랐나요?
- [x] 관련 문서를 업데이트했나요?

## 🤝 관련 이슈

- closes #163 
