### PR TITLE
fix: 토큰 재발급은 JwtAuthenticationFilter 통과 시키기 추가 (WR9-114)

### DIFF
--- a/src/main/java/io/crops/warmletter/global/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/io/crops/warmletter/global/jwt/filter/JwtAuthenticationFilter.java
@@ -57,6 +57,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
     }
 
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        return request.getRequestURI().equals("/api/reissue");
+    }
+
     // 헤더에서 토큰 추출
     private String resolveToken(HttpServletRequest request) {
         String bearerToken = request.getHeader("Authorization");


### PR DESCRIPTION
# Pull Request Template

## 📝 PR 설명

- JwtAuthenticationFilter -> 토큰 재발급 시 건너뛰도록 수정

## 🔍 주요 변경사항

- [x] JwtAuthenticationFilter shouldNotFilter 메서드 추가

## 🤝 관련 이슈

- closes #189 
