### PR TITLE
refactor: 내 편지함 목록 조회, 편지함 상세 조회 쿼리 수정 (WR9-119)

### DIFF
--- a/src/main/java/io/crops/warmletter/domain/letter/repository/LetterMatchingRepository.java
+++ b/src/main/java/io/crops/warmletter/domain/letter/repository/LetterMatchingRepository.java
@@ -41,7 +41,7 @@ public interface LetterMatchingRepository extends JpaRepository<LetterMatching, 
             "COALESCE(COUNT(l), 0)" +
             ") " +
             "FROM LetterMatching lm " +
-            "LEFT JOIN Letter l ON lm.id = l.matchingId AND l.status = 'DELIVERED' AND l.isActive = true " +
+            "LEFT JOIN Letter l ON lm.id = l.matchingId AND (l.status = 'DELIVERED' OR l.writerId = :myId) AND l.isActive = true " +
             "JOIN Member m ON (CASE WHEN lm.firstMemberId = :myId THEN lm.secondMemberId ELSE lm.firstMemberId END) = m.id " +
             "WHERE (lm.firstMemberId = :myId OR lm.secondMemberId = :myId) " +
             "GROUP BY lm.id, m.zipCode, lm.isActive " +

--- a/src/main/java/io/crops/warmletter/domain/letter/repository/LetterRepository.java
+++ b/src/main/java/io/crops/warmletter/domain/letter/repository/LetterRepository.java
@@ -15,7 +15,6 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 
@@ -39,8 +38,14 @@ public interface LetterRepository extends JpaRepository<Letter, Long> {
 
     Optional<Letter> findByIdAndWriterId(Long letterId, Long writerId);
 
-    Page<Letter> findByMatchingIdAndIsActiveTrueOrderByIdDesc(Long matchingId, Pageable pageable);
-
+    @Query("SELECT l FROM Letter l WHERE l.matchingId = :matchingId AND l.isActive = true " +
+            "AND (l.writerId = :currentUserId OR l.status = 'DELIVERED') " +
+            "ORDER BY l.id DESC")
+    Page<Letter> findDeliveredOrMyLettersByMatchingId(
+            @Param("matchingId") Long matchingId,
+            @Param("userId") Long currentUserId,
+            Pageable pageable
+    );
     List<Letter> findByReceiverIdAndStatus(Long currentUserId, Status status);
 
     @Query("SELECT new io.crops.warmletter.domain.letter.dto.response.LetterDraftResponse(" +

--- a/src/main/java/io/crops/warmletter/domain/letter/service/MailboxService.java
+++ b/src/main/java/io/crops/warmletter/domain/letter/service/MailboxService.java
@@ -10,7 +10,6 @@ import io.crops.warmletter.domain.letter.exception.MatchingNotBelongException;
 import io.crops.warmletter.domain.letter.exception.MatchingNotFoundException;
 import io.crops.warmletter.domain.letter.repository.LetterMatchingRepository;
 import io.crops.warmletter.domain.letter.repository.LetterRepository;
-import io.crops.warmletter.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -28,7 +27,6 @@ public class MailboxService {
 
     private final LetterMatchingRepository letterMatchingRepository;
     private final LetterRepository letterRepository;
-    private final MemberRepository memberRepository;
     private final AuthFacade authFacade;
 
     public List<MailboxResponse> getMailbox(){
@@ -52,7 +50,7 @@ public class MailboxService {
         }
 
         // 4. LetterRepository에서 matchingId에 해당하는 편지들을 조회
-        Page<Letter> letterPage = letterRepository.findByMatchingIdAndIsActiveTrueOrderByIdDesc(matchingId, pageable);
+        Page<Letter> letterPage = letterRepository.findDeliveredOrMyLettersByMatchingId(matchingId, myId, pageable);
 
         // 5. 조회된 Letter 엔티티들을 MailboxDetailResponse DTO로 변환
         Page<MailboxDetailResponse> responses = letterPage.map(letter ->

--- a/src/test/java/io/crops/warmletter/domain/letter/service/MailboxServiceTest.java
+++ b/src/test/java/io/crops/warmletter/domain/letter/service/MailboxServiceTest.java
@@ -236,7 +236,7 @@ class MailboxServiceTest {
         Pageable pageable = PageRequest.of(0, 10, Sort.by("id").descending());
         Page<Letter> letterPage = new PageImpl<>(letters, pageable, letters.size());
 
-        when(letterRepository.findByMatchingIdAndIsActiveTrueOrderByIdDesc(matchingId, pageable)).thenReturn(letterPage);
+        when(letterRepository.findDeliveredOrMyLettersByMatchingId(matchingId, myId, pageable)).thenReturn(letterPage);
 
         // when
         Page<MailboxDetailResponse> result = mailBoxService.detailMailbox(matchingId, pageable);
@@ -253,7 +253,7 @@ class MailboxServiceTest {
         // 호출 검증
         verify(authFacade).getCurrentUserId();
         verify(letterMatchingRepository).findById(matchingId);
-        verify(letterRepository).findByMatchingIdAndIsActiveTrueOrderByIdDesc(matchingId, pageable);
+        verify(letterRepository).findDeliveredOrMyLettersByMatchingId(matchingId, myId, pageable);
     }
 
 


### PR DESCRIPTION
# Pull Request Template

## 📝 PR 설명

- findMailboxDetails 쿼리에서 내가 보낸 편지 우선 포함하도록 수정
- detailMailbox 메서드에서 편지를 조회할 때 도착 여부를 체크 -> 도착된 편지만 조회

## 🔍 주요 변경사항

- [x] findMailboxDetails 쿼리 수정
- [x] detailMailbox 쿼리 수정 

## 📸 스크린샷 (선택사항)

- UI 변경사항이 있다면 스크린샷을 첨부해주세요.

## 🧪 테스트

- [x] 단위 테스트 추가/수정
- [x] 테스트 커버리지 확인
- [x] 소나클라우드 품질 게이트 통과

## ✅ 체크리스트

- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 코드나 주석이 없나요?
- [x] 브랜치 네이밍 컨벤션을 따랐나요?
- [x] 관련 문서를 업데이트했나요?

## 🤝 관련 이슈

- closes #198 
