### PR TITLE
fix: 임시저장 편지 조회 API 500 에러 수정 (WR9-123)

### DIFF
--- a/src/main/java/io/crops/warmletter/domain/letter/dto/response/LetterDraftResponse.java
+++ b/src/main/java/io/crops/warmletter/domain/letter/dto/response/LetterDraftResponse.java
@@ -10,6 +10,7 @@ import java.time.LocalDateTime;
 
 @Getter
 @Builder
+@AllArgsConstructor
 public class LetterDraftResponse {
 
     private final Long letterId;

--- a/src/main/java/io/crops/warmletter/domain/letter/repository/LetterRepository.java
+++ b/src/main/java/io/crops/warmletter/domain/letter/repository/LetterRepository.java
@@ -51,10 +51,20 @@ public interface LetterRepository extends JpaRepository<Letter, Long> {
     List<Letter> findByReceiverIdAndStatus(Long currentUserId, Status status);
 
     @Query("SELECT new io.crops.warmletter.domain.letter.dto.response.LetterDraftResponse(" +
-            "l.id, l.writerId, l.receiverId, l.parentLetterId, " +
-            "l.title, l.content, l.category, l.paperType, l.fontType, l.status, " +
-            "CASE WHEN m.id IS NOT NULL THEN m.isActive ELSE false END, " +
-            "l.deliveryStartedAt, l.deliveryCompletedAt, l.matchingId) " +
+            "l.id AS letterId, " +
+            "l.writerId, " +
+            "l.receiverId, " +
+            "l.parentLetterId, " +
+            "l.title, " +
+            "l.content, " +
+            "l.category, " +
+            "l.paperType, " +
+            "l.fontType, " +
+            "l.status, " +
+            "CASE WHEN m.id IS NOT NULL THEN m.isActive ELSE false END AS matched, " +
+            "l.deliveryStartedAt, " +
+            "l.deliveryCompletedAt, " +
+            "l.matchingId) " +
             "FROM Letter l LEFT JOIN LetterMatching m ON l.matchingId = m.id " +
             "WHERE l.writerId = :writerId AND l.status = :status")
     List<LetterDraftResponse> findDraftLettersWithMatching(@Param("writerId") Long writerId,


### PR DESCRIPTION
# Pull Request Template

## 📝 PR 설명

- 임시저장 편지 조회 API 500 에러 해결

## 🔍 주요 변경사항

- [x] JPQL 쿼리와 DTO 클래스 필드명 일치시킴 (l.id → letterId 별칭 추가)
- [x]  LetterDraftResponse 클래스에 @AllArgsConstructor 어노테이션 추가

## 📸 스크린샷 (선택사항)

- UI 변경사항이 있다면 스크린샷을 첨부해주세요.

## 🧪 테스트

- [x] 단위 테스트 추가/수정
- [x] 테스트 커버리지 확인
- [x] 소나클라우드 품질 게이트 통과

## ✅ 체크리스트

- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 코드나 주석이 없나요?
- [x] 브랜치 네이밍 컨벤션을 따랐나요?
- [x] 관련 문서를 업데이트했나요?

## 🤝 관련 이슈

- closes #207 
