### PR TITLE
refactor: 편지함 조회 응답 시 상대방 id값 추가 (WR9-128)

### DIFF
--- a/src/main/java/io/crops/warmletter/domain/letter/dto/response/MailboxResponse.java
+++ b/src/main/java/io/crops/warmletter/domain/letter/dto/response/MailboxResponse.java
@@ -14,15 +14,18 @@ public class MailboxResponse {
 
     private final String oppositeZipCode; //상대방의 zipcode
 
+    private final Long oppositeId; //상대방의 ID
+
     private final boolean isActive; //편지 매칭에서 활성 여부 방이 차단됐는지 안됐는지 true(활성), false(비활성)
 
     private final boolean isOppositeRead; //편지가 전부 다 읽어졌는지 아닌지 다 읽으면 true 안읽으면 false
 
     private final Long letterCount; // 총편지 수
 
-    public MailboxResponse(Long letterMatchingId, String oppositeZipCode, boolean isActive, boolean isOppositeRead, Long letterCount) {
+    public MailboxResponse(Long letterMatchingId, String oppositeZipCode, Long oppositeId, boolean isActive, boolean isOppositeRead, Long letterCount) {
         this.letterMatchingId = letterMatchingId;
         this.oppositeZipCode = oppositeZipCode;
+        this.oppositeId = oppositeId;
         this.isActive = isActive;
         this.isOppositeRead = isOppositeRead;
         this.letterCount = letterCount;

--- a/src/main/java/io/crops/warmletter/domain/letter/repository/LetterMatchingRepository.java
+++ b/src/main/java/io/crops/warmletter/domain/letter/repository/LetterMatchingRepository.java
@@ -12,33 +12,16 @@ import java.util.List;
 @Repository
 public interface LetterMatchingRepository extends JpaRepository<LetterMatching, Long> {
 
-    //firstMemberId 1이고 secondMemberId: 2면 만약 memberId가 1이면 2반환 아니면 1반환
-    @Query("SELECT DISTINCT CASE " +
-            "WHEN lm.firstMemberId = :memberId THEN lm.secondMemberId " +
-            "ELSE lm.firstMemberId END " +
-            "FROM LetterMatching lm " +
-            "WHERE lm.firstMemberId = :memberId OR lm.secondMemberId = :memberId")
-    List<Long> findMatchedMembers(@Param("memberId") Long memberId);
-
-
-    @Query("SELECT lm FROM LetterMatching lm " +
-            "WHERE (lm.firstMemberId = :myId AND lm.secondMemberId = :id) " +
-            "OR (lm.firstMemberId = :id AND lm.secondMemberId = :myId)")
-    List<LetterMatching> findMatchingIdsByMembers(Long myId, Long id);
-
     boolean existsByIdAndFirstMemberIdOrSecondMemberId(Long Id, Long firstMemberId, Long secondMemberId);
 
-    /**
-     * 	•	만약 모든 편지가 읽혔다면 SUM 값이 0이 되어 true를 반환하고,
-     * 	•	하나라도 읽지 않은 편지가 있으면 SUM이 0보다 커서 false를 반환합니다.
-     *      즉, “모든 관련 편지가 다 읽혔다면 true, 그렇지 않으면 false”가 맞습니다.
-     */
+
     @Query("SELECT new io.crops.warmletter.domain.letter.dto.response.MailboxResponse(" +
             "lm.id, " +
             "m.zipCode, " +
+            "m.id, " +
             "lm.isActive, " +
             "CASE WHEN COALESCE(SUM(CASE WHEN l.isRead = false AND l.writerId <> :myId THEN 1 ELSE 0 END), 0) = 0 THEN true ELSE false END, " +
-            "COALESCE(COUNT(l), 0)" +
+            "COALESCE(CAST(COUNT(l) AS long), 0L)" +
             ") " +
             "FROM LetterMatching lm " +
             "LEFT JOIN Letter l ON lm.id = l.matchingId AND (l.status = 'DELIVERED' OR (l.writerId = :myId AND l.status != 'SAVED')) AND l.isActive = true " +
@@ -47,20 +30,5 @@ public interface LetterMatchingRepository extends JpaRepository<LetterMatching, 
             "GROUP BY lm.id, m.zipCode, lm.isActive " +
             "ORDER BY lm.id DESC")
     List<MailboxResponse> findMailboxDetails(@Param("myId") Long myId);
-
-
-//    @Query("SELECT new io.crops.warmletter.domain.letter.dto.response.MailboxResponse(" +
-//            "lm.id, " +
-//            "m.zipCode, " +
-//            "lm.isActive, " +
-//            "CASE WHEN COUNT(l) > 0 AND COUNT(l) = SUM(CASE WHEN l.isRead = true THEN 1 ELSE 0 END) THEN true ELSE false END, " +
-//            "COUNT(l)) " +
-//            "FROM LetterMatching lm " +
-//            "JOIN Member m ON m.id = CASE WHEN lm.firstMemberId = :myId THEN lm.secondMemberId ELSE lm.firstMemberId END " +
-//            "LEFT JOIN Letter l ON l.matchingId = lm.id " +
-//            "WHERE lm.firstMemberId = :myId OR lm.secondMemberId = :myId " +
-//            "GROUP BY lm.id, m.zipCode, lm.isActive " +
-//            "ORDER BY lm.id DESC")
-//    List<MailboxResponse> findMailboxData(@Param("myId") Long myId);
 
 }


### PR DESCRIPTION
# Pull Request Template

## 📝 PR 설명

- 편지함 조회 응답 시 상대방 id값 추가

## 🔍 주요 변경사항

- [x] MailboxResponse에 oppositeId 필드 추가
- [x] findMailboxDetails 쿼리에 member id 추가

## 📸 스크린샷 (선택사항)

- UI 변경사항이 있다면 스크린샷을 첨부해주세요.

## 🧪 테스트

- [x] 단위 테스트 추가/수정
- [x] 테스트 커버리지 확인
- [x] 소나클라우드 품질 게이트 통과

## ✅ 체크리스트

- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 코드나 주석이 없나요?
- [x] 브랜치 네이밍 컨벤션을 따랐나요?
- [x] 관련 문서를 업데이트했나요?

## 🤝 관련 이슈

- closes #217 
