### PR TITLE
fix: JPQL 쿼리의 GROUP BY 누락 컬럼 오류 해결 -> only_full_group_by 모드 (WR9-130)

### DIFF
--- a/src/main/java/io/crops/warmletter/domain/letter/repository/LetterMatchingRepository.java
+++ b/src/main/java/io/crops/warmletter/domain/letter/repository/LetterMatchingRepository.java
@@ -27,7 +27,7 @@ public interface LetterMatchingRepository extends JpaRepository<LetterMatching, 
             "LEFT JOIN Letter l ON lm.id = l.matchingId AND (l.status = 'DELIVERED' OR (l.writerId = :myId AND l.status != 'SAVED')) AND l.isActive = true " +
             "JOIN Member m ON (CASE WHEN lm.firstMemberId = :myId THEN lm.secondMemberId ELSE lm.firstMemberId END) = m.id " +
             "WHERE (lm.firstMemberId = :myId OR lm.secondMemberId = :myId) " +
-            "GROUP BY lm.id, m.zipCode, lm.isActive " +
+            "GROUP BY lm.id, m.zipCode, m.id, lm.isActive " +
             "ORDER BY lm.id DESC")
     List<MailboxResponse> findMailboxDetails(@Param("myId") Long myId);
 


### PR DESCRIPTION
# Pull Request Template

## 📝 PR 설명

- JPQL 쿼리의 GROUP BY 누락 컬럼 오류 해결

## 🔍 주요 변경사항

- [x] GROUP BY 절에 m.id 추가


## 📸 스크린샷 (선택사항)

- UI 변경사항이 있다면 스크린샷을 첨부해주세요.

## 🧪 테스트

- [x] 단위 테스트 추가/수정
- [x] 테스트 커버리지 확인
- [x] 소나클라우드 품질 게이트 통과

## ✅ 체크리스트

- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 코드나 주석이 없나요?
- [x] 브랜치 네이밍 컨벤션을 따랐나요?
- [x] 관련 문서를 업데이트했나요?

## 🤝 관련 이슈

- closes #220 