### PR TITLE
Feature/get not read notification(wr9 132)

### DIFF
--- a/src/main/java/io/crops/warmletter/domain/eventpost/service/EventCommentService.java
+++ b/src/main/java/io/crops/warmletter/domain/eventpost/service/EventCommentService.java
@@ -1,6 +1,7 @@
 package io.crops.warmletter.domain.eventpost.service;
 
 import io.crops.warmletter.domain.auth.facade.AuthFacade;
+import io.crops.warmletter.domain.badword.service.BadWordService;
 import io.crops.warmletter.domain.eventpost.dto.request.CreateEventCommentRequest;
 import io.crops.warmletter.domain.eventpost.dto.response.EventCommentResponse;
 import io.crops.warmletter.domain.eventpost.entity.EventComment;
@@ -21,11 +22,13 @@ public class EventCommentService {
     private final AuthFacade authFacade;
     private final EventCommentRepository eventCommentRepository;
     private final EventPostRepository eventPostRepository;
+    private final BadWordService badWordService;
 
     public EventCommentResponse createEventComment(CreateEventCommentRequest createEventCommentRequest, Long eventPostId) {
         if(!eventPostRepository.existsByIdAndIsActiveIsTrue(eventPostId)) {
             throw new EventPostNotFoundException();
         }
+        badWordService.validateText(createEventCommentRequest.getContent());
 
         Long writerId = authFacade.getCurrentUserId();
 

--- a/src/main/java/io/crops/warmletter/domain/eventpost/service/EventPostService.java
+++ b/src/main/java/io/crops/warmletter/domain/eventpost/service/EventPostService.java
@@ -1,5 +1,6 @@
 package io.crops.warmletter.domain.eventpost.service;
 
+import io.crops.warmletter.domain.badword.service.BadWordService;
 import io.crops.warmletter.domain.eventpost.dto.request.CreateEventPostRequest;
 import io.crops.warmletter.domain.eventpost.dto.response.*;
 import io.crops.warmletter.domain.eventpost.entity.EventPost;
@@ -25,6 +26,7 @@ import java.util.Map;
 public class EventPostService {
     private final EventPostRepository eventPostRepository;
     private final EventCommentRepository eventCommentRepository;
+    private final BadWordService badWordService;
 
     @Transactional(readOnly = true)
     public Page<EventPostsResponse> getEventPosts(Pageable eventPostPageable) {
@@ -32,6 +34,8 @@ public class EventPostService {
     }
 
     public EventPostResponse createEventPost(CreateEventPostRequest createEventPostRequest) {
+        badWordService.validateText(createEventPostRequest.getTitle());
+
         EventPost eventPost = EventPost.builder()
                 .title(createEventPostRequest.getTitle())
                 .build();

--- a/src/main/java/io/crops/warmletter/domain/timeline/controller/TimelineController.java
+++ b/src/main/java/io/crops/warmletter/domain/timeline/controller/TimelineController.java
@@ -8,6 +8,7 @@ import io.crops.warmletter.global.response.PageResponse;
 import io.crops.warmletter.global.util.PageableConverter;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -16,6 +17,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -44,5 +46,11 @@ public class TimelineController {
     @Operation(summary = "모든 알림 읽음 처리", description = "로그인한 사용자의 모든 알림을 읽음 처리합니다.")
     public ResponseEntity<BaseResponse<List<ReadNotificationResponse>>> updateNotificationAllRead() {
         return ResponseEntity.ok(BaseResponse.of(timeLineService.updateNotificationAllRead(),"모든 알림 읽음 처리 성공"));
+    }
+
+    @GetMapping("/notifications/not-read")
+    @Operation(summary = "읽지 않은 알림 개수 조회", description = "로그인한 사용자의 읽지 않은 알림 개수를 조회합니다.")
+    public ResponseEntity<BaseResponse<Map<String,Integer>>> getNotificationsNotRead() {
+        return ResponseEntity.ok(BaseResponse.of(timeLineService.getNotificationNotRead(),"읽지 않은 알림 개수 조회 성공"));
     }
 }

--- a/src/main/java/io/crops/warmletter/domain/timeline/repository/TimelineRepository.java
+++ b/src/main/java/io/crops/warmletter/domain/timeline/repository/TimelineRepository.java
@@ -32,5 +32,5 @@ public interface TimelineRepository extends JpaRepository<Timeline, Long> {
     @Query("SELECT tl FROM Timeline tl WHERE tl.id IN :ids")
     List<Timeline> findByIds(@Param("ids") List<Long> ids);
 
-
+    int countByMemberIdAndIsReadIsFalse(Long memberId);
 }

--- a/src/main/java/io/crops/warmletter/domain/timeline/service/NotificationService.java
+++ b/src/main/java/io/crops/warmletter/domain/timeline/service/NotificationService.java
@@ -26,8 +26,8 @@ public class NotificationService {
     private final TimelineRepository timelineRepository;
 
     public SseEmitter subscribeNotification(){
-        SseEmitter emitter = new SseEmitter(600_000L); // 10분 후 타임아웃 설정
         Long memberId = authFacade.getCurrentUserId();
+        SseEmitter emitter = new SseEmitter(600_000L); // 10분 후 타임아웃 설정
 
         emitters.put(memberId, emitter);
 

--- a/src/main/java/io/crops/warmletter/domain/timeline/service/TimelineService.java
+++ b/src/main/java/io/crops/warmletter/domain/timeline/service/TimelineService.java
@@ -14,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -64,7 +65,12 @@ public class TimelineService {
                     .isRead(timeline.isRead())
                     .build());
         }
-
         return timelineResponses;
+    }
+
+    public Map<String,Integer> getNotificationNotRead(){
+        Long memberId = authFacade.getCurrentUserId();
+        int notReadCount = timelineRepository.countByMemberIdAndIsReadIsFalse(memberId);
+        return Map.of("notReadCount", notReadCount);
     }
 }

--- a/src/test/java/io/crops/warmletter/domain/eventpost/service/EventCommentServiceTest.java
+++ b/src/test/java/io/crops/warmletter/domain/eventpost/service/EventCommentServiceTest.java
@@ -1,6 +1,7 @@
 package io.crops.warmletter.domain.eventpost.service;
 
 import io.crops.warmletter.domain.auth.facade.AuthFacade;
+import io.crops.warmletter.domain.badword.service.BadWordService;
 import io.crops.warmletter.domain.eventpost.dto.request.CreateEventCommentRequest;
 import io.crops.warmletter.domain.eventpost.dto.response.EventCommentResponse;
 import io.crops.warmletter.domain.eventpost.entity.EventComment;
@@ -38,8 +39,13 @@ class EventCommentServiceTest {
     @Mock
     private AuthFacade authFacade;
 
+    @Mock
+    private BadWordService badWordService;
+
     @InjectMocks
     private EventCommentService eventCommentService;
+
+
 
     @Test
     @DisplayName("게시판 댓글 생성 성공")
@@ -59,10 +65,12 @@ class EventCommentServiceTest {
                 .build();
         ReflectionTestUtils.setField(eventComment, "id", 1L);
 
+
         when(eventPostRepository.existsByIdAndIsActiveIsTrue(1L)).thenReturn(true);
         when(eventCommentRepository.save(any(EventComment.class))).thenReturn(eventComment);
 
         //when
+        badWordService.validateText(createEventCommentRequest.getContent());
         EventCommentResponse eventCommentResponse = eventCommentService.createEventComment(createEventCommentRequest,1L);
 
         //then

--- a/src/test/java/io/crops/warmletter/domain/eventpost/service/EventPostServiceTest.java
+++ b/src/test/java/io/crops/warmletter/domain/eventpost/service/EventPostServiceTest.java
@@ -1,5 +1,6 @@
 package io.crops.warmletter.domain.eventpost.service;
 
+import io.crops.warmletter.domain.badword.service.BadWordService;
 import io.crops.warmletter.domain.eventpost.dto.request.CreateEventPostRequest;
 import io.crops.warmletter.domain.eventpost.dto.response.*;
 import io.crops.warmletter.domain.eventpost.entity.EventPost;
@@ -35,6 +36,9 @@ class EventPostServiceTest {
 
     @Mock
     private EventCommentRepository eventCommentRepository;
+
+    @Mock
+    private BadWordService badWordService;
 
     @InjectMocks
     private EventPostService eventPostService;
@@ -83,6 +87,7 @@ class EventPostServiceTest {
         when(eventPostRepository.save(any(EventPost.class))).thenReturn(eventPost);
 
         //when
+        badWordService.validateText(createEventPostRequest.getTitle());
         EventPostResponse eventPostResponse = eventPostService.createEventPost(createEventPostRequest);
 
         //then

--- a/src/test/java/io/crops/warmletter/domain/timeline/controller/TimelineControllerTest.java
+++ b/src/test/java/io/crops/warmletter/domain/timeline/controller/TimelineControllerTest.java
@@ -19,6 +19,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.any;
@@ -116,5 +117,19 @@ class TimelineControllerTest {
                 .andDo(print());
     }
 
+    @Test
+    @DisplayName("GET 읽지 않은 알림 개수 조회 성공")
+    void get_notificationNotRead_success() throws Exception {
+        // given
+        Map<String, Integer> respnse = Map.of("notReadCount",2);
 
+        when(timelineService.getNotificationNotRead()).thenReturn(respnse);
+
+        // when & then
+        mockMvc.perform(get("/api/notifications/not-read"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.notReadCount").value(2))
+                .andExpect(jsonPath("$.message").value("읽지 않은 알림 개수 조회 성공"))
+                .andDo(print());
+    }
 }

--- a/src/test/java/io/crops/warmletter/domain/timeline/service/TimelineServiceTest.java
+++ b/src/test/java/io/crops/warmletter/domain/timeline/service/TimelineServiceTest.java
@@ -22,6 +22,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -42,7 +43,7 @@ class TimelineServiceTest {
 
     @Test
     @DisplayName("타임라인 조회 성공")
-    void get_EventPost_success(){
+    void get_eventPost_success(){
         // given
         Long memberId = 1L;
         when(authFacade.getCurrentUserId()).thenReturn(memberId);
@@ -154,5 +155,21 @@ class TimelineServiceTest {
         assertTrue(readNotificationResponse.get(0).isRead());
         assertEquals(3L, readNotificationResponse.get(1).getNotificationId());
         assertTrue(readNotificationResponse.get(1).isRead());
+    }
+
+    @Test
+    @DisplayName("읽지 않은 알림 개수 조회 성공")
+    void get_notificationNotRead_success(){
+        // given
+        int notReadCount = 2;
+
+        when(timelineRepository.countByMemberIdAndIsReadIsFalse(any(Long.class))).thenReturn(notReadCount);
+
+        // when
+        Map<String, Integer> timelineResponse = timelineService.getNotificationNotRead();
+
+        // then
+        assertNotNull(timelineResponse);
+        assertEquals(notReadCount, timelineResponse.get("notReadCount"));
     }
 }


### PR DESCRIPTION
# Pull Request Template

## 📝 PR 설명

- 안 읽은 알림 개수 조회 API 구현

## 🔍 주요 변경사항

- [x] GET /api/notifications/not-read 엔드 포인트 추가
- [x] 안 읽은 알림 개수 조회 API 구현
- [x] 검열 메서드 추가(이벤트 게시판, 댓글 생성)

## 📸 스크린샷 (선택사항)

- UI 변경사항이 있다면 스크린샷을 첨부해주세요.

## 🧪 테스트

- [x] 단위 테스트 추가/수정
- [x] 테스트 커버리지 확인
- [x] 소나클라우드 품질 게이트 통과

## ✅ 체크리스트

- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 코드나 주석이 없나요?
- [x] 브랜치 네이밍 컨벤션을 따랐나요?
- [x] 관련 문서를 업데이트했나요?

## 🤝 관련 이슈

- closes #224 
