### PR TITLE
Feature/badword delete(wr9 138)

### DIFF
--- a/src/main/java/io/crops/warmletter/domain/badword/controller/BadWordController.java
+++ b/src/main/java/io/crops/warmletter/domain/badword/controller/BadWordController.java
@@ -59,4 +59,9 @@ public class BadWordController {
         return ResponseEntity.ok(BaseResponse.of(response, "금칙어 변경 성공"));
     }
 
+    @DeleteMapping("/{badwordId}")
+    public ResponseEntity<BaseResponse<String>> deleteBadWord(@PathVariable("badwordId") Long badWordId) {
+        badWordService.deleteBadWord(badWordId);
+        return ResponseEntity.ok(BaseResponse.of(null, "금칙어 영구삭제"));
+    }
 }

--- a/src/main/java/io/crops/warmletter/domain/badword/service/BadWordService.java
+++ b/src/main/java/io/crops/warmletter/domain/badword/service/BadWordService.java
@@ -26,7 +26,7 @@ public class BadWordService {
     private final RedisTemplate<String, String> redisTemplate; // Redis 추가
 
     private static final String BAD_WORD_KEY = "bad_word";
-    private static final String BAD_WORD_PATTERN = "[^가-힣a-zA-Z0-9]";
+    private static final String BAD_WORD_PATTERN = "[^가-힣ㄱ-ㅎㅏ-ㅣa-zA-Z0-9]";
 
     public void createBadWord(CreateBadWordRequest request) {
         String word = request.getWord();
@@ -93,6 +93,18 @@ public class BadWordService {
         return new UpdateBadWordResponse(badWord.getWord());
     }
 
+    @Transactional
+    public void deleteBadWord(Long id) {
+        BadWord badWord = badWordRepository.findById(id)
+                .orElseThrow(BadWordNotFoundException:: new);
+
+        badWordRepository.delete(badWord);
+
+        redisTemplate.opsForHash().delete(BAD_WORD_KEY, id.toString());
+    }
+
+
+
     //필터링
     public void validateText(String text) {
         Map<Object, Object> entries = redisTemplate.opsForHash().entries(BAD_WORD_KEY);
@@ -106,7 +118,7 @@ public class BadWordService {
 
         for (String badWord : badWords) {
             // 금칙어도 혹시 특수문자 있을 수 있으니까 정제
-            String sanitizedBadWord = badWord.replaceAll("[^가-힣a-zA-Z0-9]", "");
+            String sanitizedBadWord = badWord.replaceAll(BAD_WORD_PATTERN, "");
 
             if (sanitizedText.contains(sanitizedBadWord)) {
                 throw new BadWordContainsException();

--- a/src/test/java/io/crops/warmletter/domain/badword/controller/BadWordControllerTest.java
+++ b/src/test/java/io/crops/warmletter/domain/badword/controller/BadWordControllerTest.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import static org.mockito.Mockito.doNothing;
 
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -139,4 +140,18 @@ class BadWordControllerTest {
                 .andExpect(jsonPath("$.message").value("금칙어 변경 성공"));
     }
 
+    @Test
+    @DisplayName("금칙어 영구삭제 컨트롤러 테스트 - 성공")
+    void deleteBadWord_Success() throws Exception {
+        // 테스트용 금칙어 id
+        Long badwordId = 1L;
+
+        // badWordService.deleteBadWord(badwordId) 호출 시 아무 작업도 하지 않도록 설정
+        doNothing().when(badWordService).deleteBadWord(badwordId);
+
+        // DELETE 요청을 보내고, 응답 상태와 메시지 검증
+        mockMvc.perform(delete("/api/bad-words/{badwordId}", badwordId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("금칙어 영구삭제"));
+    }
 }

--- a/src/test/java/io/crops/warmletter/domain/badword/service/BadWordServiceTest.java
+++ b/src/test/java/io/crops/warmletter/domain/badword/service/BadWordServiceTest.java
@@ -1,6 +1,7 @@
 package io.crops.warmletter.domain.badword.service;
 
 import io.crops.warmletter.config.TestConfig;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import io.crops.warmletter.domain.badword.dto.request.CreateBadWordRequest;
 import io.crops.warmletter.domain.badword.dto.request.UpdateBadWordRequest;
 import io.crops.warmletter.domain.badword.dto.request.UpdateBadWordStatusRequest;
@@ -283,4 +284,31 @@ class BadWordServiceTest {
         assertEquals("newWord", response.getWord());
     }
 
+    @Test
+    @DisplayName("deleteBadWord - 성공 케이스: 존재하는 금칙어 삭제")
+    void deleteBadWord_success() {
+        // given
+        Long badWordId = 1L;
+        BadWord badWord = new BadWord();
+        // 필요한 경우 badWord에 속성을 추가할 수 있습니다.
+        when(badWordRepository.findById(badWordId)).thenReturn(Optional.of(badWord));
+
+        // when
+        badWordService.deleteBadWord(badWordId);
+
+        // then: 리포지토리에서 delete() 메서드 호출 및 Redis에서 삭제 호출 검증
+        verify(badWordRepository).delete(badWord);
+        verify(hashOperations).delete(BAD_WORD_KEY, badWordId.toString());
+    }
+
+    @Test
+    @DisplayName("deleteBadWord - 실패 케이스: 존재하지 않는 금칙어 삭제 시 예외 발생")
+    void deleteBadWord_notFound() {
+        // given
+        Long badWordId = 2L;
+        when(badWordRepository.findById(badWordId)).thenReturn(Optional.empty());
+
+        // when & then: BadWordNotFoundException 발생 검증
+        assertThrows(BadWordNotFoundException.class, () -> badWordService.deleteBadWord(badWordId));
+    }
 }


### PR DESCRIPTION
# Pull Request Template

## 📝 PR 설명

- 금칙어 영구삭제 api기능추가
- 기존 정규표현식이 한글 완성형(가-힣)과 영문, 숫자만 허용하여 한글 자모(ㄱ-ㅎ, ㅏ-ㅣ)를 모두 제거하는 문제가 있었습니다.
이제 정규표현식을 [^가-힣ㄱ-ㅎㅏ-ㅣa-zA-Z0-9]로 수정하여, 한글 자모도 허용하도록 변경했습니다.

## 🔍 주요 변경사항

- [ ] 영구삭제 api
- [ ] 정규표현식 수정


## 📸 스크린샷 (선택사항)

- UI 변경사항이 있다면 스크린샷을 첨부해주세요.

## 🧪 테스트

- [ ] 단위 테스트 추가/수정
- [ ] 테스트 커버리지 확인
- [ ] 소나클라우드 품질 게이트 통과

## ✅ 체크리스트

- [ ] 코드 컨벤션을 준수했나요?
- [ ] 불필요한 코드나 주석이 없나요?
- [ ] 브랜치 네이밍 컨벤션을 따랐나요?
- [ ] 관련 문서를 업데이트했나요?

## 🤝 관련 이슈

- closes #이슈번호
